### PR TITLE
fix: #32 when creating bitmap with bitmap.Of(), the least bit count n…

### DIFF
--- a/bitmap/of.go
+++ b/bitmap/of.go
@@ -21,6 +21,9 @@ func Of(bitPositions []int32, opts ...int32) []uint64 {
 			n = max
 		}
 	}
+	if n < 0 {
+		n = 0
+	}
 
 	nWords := (n + 63) >> 6
 	words := make([]uint64, nWords)

--- a/bitmap/of_test.go
+++ b/bitmap/of_test.go
@@ -69,6 +69,10 @@ func TestOf_with_n(t *testing.T) {
 			[]uint64{},
 		},
 		{
+			[]int32{}, -100,
+			[]uint64{},
+		},
+		{
 			[]int32{}, 1,
 			[]uint64{0},
 		},
@@ -91,6 +95,10 @@ func TestOf_with_n(t *testing.T) {
 		},
 		{
 			[]int32{0}, -1,
+			[]uint64{1},
+		},
+		{
+			[]int32{0}, -100,
 			[]uint64{1},
 		},
 		{
@@ -121,6 +129,10 @@ func TestOf_with_n(t *testing.T) {
 		},
 		{
 			[]int32{0, 1, 2}, -1,
+			[]uint64{7},
+		},
+		{
+			[]int32{0, 1, 2}, -100,
 			[]uint64{7},
 		},
 		{
@@ -155,6 +167,10 @@ func TestOf_with_n(t *testing.T) {
 		},
 		{
 			[]int32{64}, -1,
+			[]uint64{0, 1},
+		},
+		{
+			[]int32{64}, -100,
 			[]uint64{0, 1},
 		},
 		{

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/openacid/errors v0.8.1 h1:Hrj9WENDoj5jP27ZfF60SY5LShbxei+sxKZa0EP+oDw
 github.com/openacid/errors v0.8.1/go.mod h1:GUQEJJOJE3W9skHm8E8Y4phdl2LLEN8iD7c5gcGgdx0=
 github.com/openacid/must v0.1.3 h1:deanGZVyVwV+ozfwNFbRU5YF7czXeQ67s8GVyZxzKW4=
 github.com/openacid/must v0.1.3/go.mod h1:luPiXCuJlEo3UUFQngVQokV0MPGryeYvtCbQPs3U1+I=
-github.com/openacid/testkeys v0.1.6 h1:vuQZu/NM6nJo0OKUcaFNtm76Rnv3fMIIXrjp0gFX7FM=
-github.com/openacid/testkeys v0.1.6/go.mod h1:MfA7cACzBpbiwekivj8StqX0WIRmqlMsci1c37CA3Do=
 github.com/openacid/testkeys v0.1.7 h1:8mai/cJLsVvBob8K9RrXilkatK4oahfCZdxDJ8CUK7I=
 github.com/openacid/testkeys v0.1.7/go.mod h1:MfA7cACzBpbiwekivj8StqX0WIRmqlMsci1c37CA3Do=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
… should be allowed to be any negative int

# Description

<!-- Please include a summary of the change.
     Please also include relevant motivation and context.
     List any dependencies that are required for this change.
-->

Fixes #32 

## Type of change

<!-- Please delete options that are not relevant. -->

- **Bug fix**         <!-- non-breaking change which fixes an issue -->




## The solution (to fix a bug, implement a new feature etc.)



# Checklist:

- [ ] **Style**:       My code follows the **style guidelines** of this project
- [ ] **Self-review**: I have performed a **self-review** of my own code
- [ ] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [ ] **Doc**:         I have made corresponding changes to the **documentation**
- [ ] **No-warnings**: My changes generate **no new warnings**
- [ ] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [ ] **Pass**:        New and existing **unit tests pass** locally with my changes
- [ ] **Dep**:         Any **dependent** changes have been merged and published in downstream modules
